### PR TITLE
Detect changes to vagrant_provision.sh on login.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant/
 build/
+.vagrant_provision.backup

--- a/utility/provision_diff.py
+++ b/utility/provision_diff.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+from os import chdir
+from os.path import exists, join
+
+import shutil
+
+header = ['#!/bin/sh', 'set -e', 'set -x']
+
+DIFF_DIR = '/home/vagrant'
+DIFF_FILE = 'provision_diff.sh'
+BACKUP_FILE = '.vagrant_provision.backup'
+
+if __name__ == '__main__':
+    chdir('/home/vagrant/rdfs/')
+    # If backup exists, check if it differs from the provision file.
+    if exists(BACKUP_FILE):
+        with open(BACKUP_FILE) as backup:
+            backup_lines = backup.readlines()
+            with open('vagrant_provision.sh') as provision:
+                diff = [line for line in provision.readlines() if line not in
+                        backup_lines]
+                if diff:
+                    with open(join(DIFF_DIR, DIFF_FILE), 'w') as fdiff:
+                        fdiff.writelines(header + diff)
+                    print "Detected changes in vagrant provision since last ssh:"
+                    print ''.join(diff)
+                    print "Use `sudo sh {}` to execute.".format(DIFF_FILE)
+                else:
+                    print "No changes in vagrant_provision.sh detected."
+    # Otherwise just copy provision file into it.
+    else:
+        print "No backup exists, creating one now..."
+    # Update the backup file.
+    shutil.copy('vagrant_provision.sh', BACKUP_FILE)

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -53,6 +53,8 @@ cat > /home/vagrant/hadoop/etc/hdfs-site.xml <<EOF
 EOF
 # add hadoop to path
 echo 'export PATH=/home/vagrant/hadoop/bin:$PATH' >> /home/vagrant/.bashrc
+# add diff detector to path
+echo 'python /home/vagrant/rdfs/utility/provision_diff.py' >> /home/vagrant/.bashrc
 
 # TODO: Setup Apache zookeeper
 


### PR DESCRIPTION
This PR adds a script which runs on login (executed from .bashrc) and does the following:
1. Does .vagrant_provision.backup exist?
   - If yes, check whether all lines in vagrant_provision.sh exist in the backup files.
   - Copy all detected added/changed lines to provision_diff.sh and prompt you to run provision_diff.sh.
2. Then create new backup file from current provision.

Because chickens and eggs, upon merge this will not run automatically, you will have to make one (last?) manual adjustment by executing:
`echo 'python /home/vagrant/rdfs/utility/provision_diff.py' >> /home/vagrant/.bashrc`

Then when you login via vagrant ssh, if provision has changed since last ssh, the difference will be printed along with the instruction to execute if it looks correct.
