### PR TITLE
Start datanode RPC by running transfer server in its own thread,

### DIFF
--- a/rice-datanode/source/main.cc
+++ b/rice-datanode/source/main.cc
@@ -2,6 +2,7 @@
 #define ELPP_THREAD_SAFE
 
 #include <cstdlib>
+#include <thread>
 #include <iostream>
 #include <asio.hpp>
 #include <rpcserver.h>
@@ -35,6 +36,6 @@ int main(int argc, char* argv[]) {
 	zkclient::ZkClientDn dncli("127.0.0.1", "localhost", "localhost:2181", ipcPort, xferPort); // TODO: Change the datanode id
 	ClientDatanodeTranslator translator(ipcPort);
 	TransferServer transfer_server(xferPort, fs, dncli);
-	transfer_server.serve(io_service);
+	std::thread(&TransferServer::serve, transfer_server, std::ref(io_service)).detach();
 	translator.getRPCServer().serve(io_service);
 }


### PR DESCRIPTION
fixes #65.