### PR TITLE
Implement coalescing of free blocks with test.

### DIFF
--- a/native-filesystem/include/native_filesystem.h
+++ b/native-filesystem/include/native_filesystem.h
@@ -27,7 +27,7 @@ namespace nativefs {
 	constexpr size_t BLOCK_LIST_LEN = DISK_SIZE / MIN_BLOCK_SIZE;
 	constexpr size_t BLOCK_LIST_SIZE = BLOCK_LIST_LEN * sizeof(block_info);
 	// If MAGIC changes, make sure to change the 8 in RESERVED_SIZE too.
-	const std::string MAGIC = "OPNSESME";
+	const std::string MAGIC = "DEADBEEF";
 	// Reserved space for magic bytes + block_info array.
 	constexpr size_t RESERVED_SIZE = BLOCK_LIST_SIZE + 8;
 

--- a/native-filesystem/include/native_filesystem.h
+++ b/native-filesystem/include/native_filesystem.h
@@ -15,6 +15,7 @@ namespace nativefs {
 		uint64_t blockid;
 		uint64_t offset;
 		uint32_t len;
+		bool free;
 	} block_info;
 
 	const size_t MIN_BLOCK_POWER = 13;
@@ -75,7 +76,15 @@ class NativeFS{
 		 * Mark the area of disk from start to end as free.
 		 */
 		void freeRange(uint64_t start, uint64_t end);
+		/**
+		 * Allocate space to fit provided size, write position to offset.
+		 * Return true if space was found, otherwise false.
+		 */
 		bool allocateBlock(size_t size, uint64_t& offset);
+		/**
+		 * Build the free ranges from allocated blocks.
+		 */
+		void constructFreeLists();
 		/**
 		 * Persist current block metadata to storage.
 		 */

--- a/test/native-filesystem/native_fs_tests.cc
+++ b/test/native-filesystem/native_fs_tests.cc
@@ -7,23 +7,24 @@ using ::testing::AtLeast;
 
 using namespace nativefs;
 class NativeFSTest : public ::testing::Test {
-	public:
-		NativeFSTest() : filesystem("/dev/sdb") {}
 protected:
 	virtual void SetUp() {
 		blk = "here's some data to write in the block";
+		backing = "_NATIVEFS_TEST_FS";
 	}
 	std::string blk;
-	NativeFS filesystem;
+	std::string backing;
 };
 
 // TODO: Test writing and getting multiple blocks
 
 TEST_F(NativeFSTest, CanWriteBlock) {
+	NativeFS filesystem(backing);
 	ASSERT_EQ(true, filesystem.writeBlock(1, blk));
 }
 
 TEST_F(NativeFSTest, CanGetBlock) {
+	NativeFS filesystem(backing);
 	bool write_success = filesystem.writeBlock(2, blk);
 	ASSERT_EQ(true, write_success);
 	std::string newBlock;
@@ -33,17 +34,47 @@ TEST_F(NativeFSTest, CanGetBlock) {
 }
 
 TEST_F(NativeFSTest, CanRemoveBlock) {
+	NativeFS filesystem(backing);
 	ASSERT_EQ(true, filesystem.rmBlock(1));
 	ASSERT_EQ(true, filesystem.rmBlock(2));
 }
 
 TEST_F(NativeFSTest, RemoveNonExistBlockReturnsError) {
+	NativeFS filesystem(backing);
 	ASSERT_EQ(false, filesystem.rmBlock(3));
+}
+
+TEST_F(NativeFSTest, CanCoalesce) {
+	NativeFS filesystem(backing);
+	// Fill the disk with blocks of size 1/2 MAX BLOCK.
+	{
+		std::string halfblk(MAX_BLOCK_SIZE / 2, 'z');
+		for (int i = 0; i < (DISK_SIZE - RESERVED_SIZE) / (MAX_BLOCK_SIZE / 2); i++) {
+			ASSERT_TRUE(filesystem.writeBlock(i, halfblk));
+		}
+	}
+	// Then free the blocks and attempt to add block of size MAX BLOCK.
+	{
+		std::string fullblk(MAX_BLOCK_SIZE, 'z');
+		for (int i = 0; i < (DISK_SIZE - RESERVED_SIZE) / (MAX_BLOCK_SIZE / 2); i++) {
+			ASSERT_TRUE(filesystem.rmBlock(i));
+		}
+		// Now write a few big blocks.
+		for (int i = 0; i < (DISK_SIZE - RESERVED_SIZE) / MAX_BLOCK_SIZE; i++) {
+			std::string readblk;
+			ASSERT_TRUE(filesystem.writeBlock(i, fullblk));
+			ASSERT_TRUE(filesystem.getBlock(i, readblk));
+			// Make sure contents are the same.
+			ASSERT_EQ(fullblk, readblk);
+		}
+	}
 }
 
 int main(int argc, char **argv) {
 	::testing::InitGoogleTest(&argc, argv);
 	::testing::InitGoogleMock(&argc, argv);
+	system("truncate -s 1000000000 _NATIVEFS_TEST_FS");
 	int result = RUN_ALL_TESTS();
+	system("rm -f _NATIVEFS_TEST_FS");
 	return result;
 }


### PR DESCRIPTION
Also add class name in logs from native filesystem code.

And by adding free marker to block list it will allow blocks with id 0.

Finally fix an issue with starting free ranges at offset 0, where the important metadata lives.