### PR TITLE
Only flush the changed block on add and remove.

### DIFF
--- a/native-filesystem/include/native_filesystem.h
+++ b/native-filesystem/include/native_filesystem.h
@@ -104,7 +104,11 @@ class NativeFS{
 		/**
 		 * Persist current block metadata to storage.
 		 */
-		void flushBlocks();
+		void flushAllBlocks();
+		/**
+		 * Persist one particular block to storage.
+		 */
+		void flushBlock(long block_index);
 
 		/**
 		 * For debugging, print the free blocks.


### PR DESCRIPTION
This change can help if the block list is large so we only write back one block info when necessary.